### PR TITLE
bindShared() changed to singleton()

### DIFF
--- a/src/Cohensive/Embed/EmbedServiceProvider.php
+++ b/src/Cohensive/Embed/EmbedServiceProvider.php
@@ -19,7 +19,7 @@ class EmbedServiceProvider extends ServiceProvider
 	public function register()
 	{
 		$this->package('cohensive/embed');
-		$this->app->bindShared('embed', function($app) {
+		$this->app->singleton('embed', function($app) {
 			return new Factory($app);
 		});
 	}


### PR DESCRIPTION
It looks like bindShared was changed to singleton. After updating, the package started working on laravel 4.0.x.